### PR TITLE
Refresh Metadata on Sync

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -166,7 +166,7 @@ async function main() {
 
   setupWebsocketServer(server)
 
-  const cache = new Cache(180)
+  const cache = new Cache(ENVIRONMENT === 'development' ? 0 : 180)
   const observer = new Observer()
   app.set('cache', cache)
   app.set('observer', observer)

--- a/server/src/services/TmdbService.js
+++ b/server/src/services/TmdbService.js
@@ -93,6 +93,21 @@ service.getSeason = async (tmdbId, season) => {
   }
 }
 
+service.getEpisode = async (tmdbId, season, episode) => {
+  try {
+    const res = (await api.get(`tv/${tmdbId}/season/${season}/episode/${episode}`, {
+      params: { 
+        language: 'en-US,null',
+        // append_to_response: 'images'
+      },
+      ...options
+    })).data
+    return res
+  } catch (err) {
+    throw new Error(`tv/${tmdbId}/season/${season}/episode/${episode} - ${err.response.status} - ${err.response.statusText}`)
+  }
+}
+
 // "backdrop_sizes": [
 //   "w300",
 //   "w780",

--- a/ui/src/views/Series.js
+++ b/ui/src/views/Series.js
@@ -197,7 +197,7 @@ const Series = ({ sidebarOpen, setStats }) => {
                         }} fontSize="inherit" />
                       }
                     >
-                      Sync Series Files
+                      Sync Series
                     </Button>
                     <Button onClick={handleFixMatch} variant="outlined" size="small">
                       Fix Match


### PR DESCRIPTION
query for individual episode data if season data wasn't already grabbed, refresh metadata on sync, add episode endpoint to tmdb service

FIX #6 